### PR TITLE
feat: pass filename to svelte.preprocess

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,7 @@ export default function svelte(options = {}) {
 			if (!filter(id)) return null;
 			if (!~extensions.indexOf(path.extname(id))) return null;
 
-			return (options.preprocess ? preprocess(code, options.preprocess) : Promise.resolve(code)).then(code => {
+			return (options.preprocess ? preprocess(code, Object.assign({}, options.preprocess, { id })) : Promise.resolve(code)).then(code => {
 				const compiled = compile(
 					code.toString(),
 					Object.assign({}, {

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,7 @@ export default function svelte(options = {}) {
 			if (!filter(id)) return null;
 			if (!~extensions.indexOf(path.extname(id))) return null;
 
-			return (options.preprocess ? preprocess(code, Object.assign({}, options.preprocess, { id })) : Promise.resolve(code)).then(code => {
+			return (options.preprocess ? preprocess(code, Object.assign({}, options.preprocess, { filename : id })) : Promise.resolve(code)).then(code => {
 				const compiled = compile(
 					code.toString(),
 					Object.assign({}, {

--- a/test/test.js
+++ b/test/test.js
@@ -137,9 +137,11 @@ describe('rollup-plugin-svelte', () => {
 	it('preprocesses components', () => {
 		const { transform } = plugin({
 			preprocess: {
-				markup: ({ content }) => {
+				markup: ({ content, filename }) => {
 					return {
-						code: content.replace('__REPLACEME__', 'replaced')
+						code: content
+							.replace('__REPLACEME__', 'replaced')
+							.replace('__FILENAME__', filename)
 					};
 				}
 			}
@@ -147,8 +149,10 @@ describe('rollup-plugin-svelte', () => {
 
 		return transform(`
 			<h1>Hello __REPLACEME__!</h1>
+			<h2>file: __FILENAME__</h2>
 		`, 'test.html').then(({ code }) => {
-			assert.equal(code.indexOf('__REPLACEME__'), -1);
+			assert.equal(code.indexOf('__REPLACEME__'), -1, 'content not modified');
+			assert.notEqual(code.indexOf('file: test.html'), -1, 'filename not replaced');
 		});
 	});
 });


### PR DESCRIPTION
Once https://github.com/sveltejs/svelte/pull/987 lands this will make it so that `rollup-plugin-svelte` will pass the `id` to `svelte.preprocess()` as the `filename` param.

Implements the other part of what I was talking about in https://github.com/sveltejs/svelte/issues/983

The test will **fail** until https://github.com/sveltejs/svelte/pull/987 is merged & released, not much I can do about that beyond mocking out `svelte.preprocess()` which I'm happy to do if @Rich-Harris prefers.