### PR TITLE
Error: you must specify format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ import * as fs from 'fs';
 import svelte from 'rollup-plugin-svelte';
 
 export default {
-  entry: 'src/main.js',
-  dest: 'public/bundle.js',
-  format: 'iife',
+  input: 'src/main.js',
+  output: {
+    file: 'public/bundle.js',
+    format: 'iife'
+  },
   plugins: [
     svelte({
       // By default, all .html and .svelte files are compiled


### PR DESCRIPTION
Seems that rollup has changed how it likes to be configured. Syntax from: https://rollupjs.org/guide/en#using-plugins