### PR TITLE
Append inline sourcemaps with `emitCss: true`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,11 +206,17 @@ export default function svelte(options = {}) {
 
 				if ((css || options.emitCss) && compiled.css.code) {
 					let fname = id.replace('.html', '.css');
-					cssLookup.set(fname, compiled.css);
+
+					let { code } = compiled.css;
+
 					if (options.emitCss) {
+						const source_map_comment = `/*# sourceMappingURL=${compiled.css.map.toUrl()} */`;
+						code += `\n${source_map_comment}`;
+
 						compiled.js.code += `\nimport '${fname}';\n`;
 					}
 
+					cssLookup.set(fname, code);
 				}
 
 				return compiled.js;

--- a/src/index.js
+++ b/src/index.js
@@ -207,16 +207,14 @@ export default function svelte(options = {}) {
 				if ((css || options.emitCss) && compiled.css.code) {
 					let fname = id.replace('.html', '.css');
 
-					let { code } = compiled.css;
-
 					if (options.emitCss) {
 						const source_map_comment = `/*# sourceMappingURL=${compiled.css.map.toUrl()} */`;
-						code += `\n${source_map_comment}`;
+						compiled.css.code += `\n${source_map_comment}`;
 
 						compiled.js.code += `\nimport '${fname}';\n`;
 					}
 
-					cssLookup.set(fname, code);
+					cssLookup.set(fname, compiled.css);
 				}
 
 				return compiled.js;


### PR DESCRIPTION
This makes it possible to extract sourcemap information when CSS is destined to be written out as a separate file, rather than inlined CSS-in-JS style. See https://github.com/sveltejs/sapper/issues/388 for more info