### PR TITLE
Call custom onwarn with rollup handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,12 +195,14 @@ export default function svelte(options = {}) {
 			return (options.preprocess ? preprocess(code, Object.assign({}, options.preprocess, { filename : id })) : Promise.resolve(code)).then(code => {
 				const compiled = compile(
 					code.toString(),
-					Object.assign({}, {
+					Object.assign({}, fixedOptions, {
 						onwarn: warning => {
 							if ((options.css || !options.emitCss) && warning.code === 'css-unused-selector') return;
-							this.warn(warning);
+							fixedOptions.onwarn
+								? fixedOptions.onwarn(warning, this.warn)
+								: this.warn(warning);
 						}
-					}, fixedOptions, {
+					}, {
 						name: capitalize(sanitize(id)),
 						filename: id
 					})


### PR DESCRIPTION
Currently if the user passes a custom `onwarn` function to the svelte config then rollup error handling is bypassed and errors get reported through svelte. This pull request calls user provider `onwarn` functions with `this.warn` as the handler allowing rollup to handle the final warnings.