### PR TITLE
use this.addWatchFile when present

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,11 @@ module.exports = function svelte(options = {}) {
 					cssLookup.set(fname, compiled.css);
 				}
 
-				compiled.js.dependencies = dependencies;
+				if (this.addWatchFile) {
+					dependencies.forEach(dependency => this.addWatchFile(dependency));
+				} else {
+					compiled.js.dependencies = dependencies;
+				}
 
 				return compiled.js;
 			});


### PR DESCRIPTION
To avoid deprecation warning in Rollup 1.0+

I don't know what version `this.addWatchFile` was added in, but it's not present in the earliest version of Rollup listed as a peer dependency of this plugin, so this change isn't assuming it's present. It falls back to the old behavior if it's not.