### PR TITLE
Fix support for array of preprocessors

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,18 +208,15 @@ module.exports = function svelte(options = {}) {
 			const dependencies = [];
 			let preprocessPromise;
 			if (options.preprocess) {
-				const preprocessOptions = {};
-				for (const key in options.preprocess) {
-					preprocessOptions[key] = (...args) => {
-						return Promise.resolve(options.preprocess[key](...args)).then(resp => {
-							if (resp && resp.dependencies) {
-								dependencies.push(...resp.dependencies);
-							}
-							return resp;
-						});
-					};
-				}
-				preprocessPromise = preprocess(code, Object.assign(preprocessOptions, { filename: id })).then(code => code.toString());
+				options.preprocess.filename = id;
+				preprocessPromise = preprocess(code, options.preprocess).then(
+					processed => {
+						if (processed.dependencies) {
+							dependencies.push(...processed.dependencies);
+						}
+						return processed.toString();
+					}
+				);
 			} else {
 				preprocessPromise = Promise.resolve(code);
 			}

--- a/index.js
+++ b/index.js
@@ -208,15 +208,34 @@ module.exports = function svelte(options = {}) {
 			const dependencies = [];
 			let preprocessPromise;
 			if (options.preprocess) {
-				options.preprocess.filename = id;
-				preprocessPromise = preprocess(code, options.preprocess).then(
-					processed => {
+				if (major_version < 3) {
+					const preprocessOptions = {};
+					for (const key in options.preprocess) {
+						preprocessOptions[key] = (...args) => {
+							return Promise.resolve(options.preprocess[key](...args)).then(
+								resp => {
+									if (resp && resp.dependencies) {
+										dependencies.push(...resp.dependencies);
+									}
+									return resp;
+								}
+							);
+						};
+					}
+					preprocessPromise = preprocess(
+						code,
+						Object.assign(preprocessOptions, { filename: id })
+					).then(code => code.toString());
+				} else {
+					preprocessPromise = preprocess(code, options.preprocess, {
+						filename: id
+					}).then(processed => {
 						if (processed.dependencies) {
 							dependencies.push(...processed.dependencies);
 						}
 						return processed.toString();
-					}
-				);
+					});
+				}
 			} else {
 				preprocessPromise = Promise.resolve(code);
 			}


### PR DESCRIPTION
The current code is creating a new `object` from the passed `options.preprocess`, which turns an `array` of preprocessors into a plain `object`. That would be okay if it wasn't for [this line in the svelte compiler](https://github.com/sveltejs/svelte/blob/master/src/preprocess/index.ts#L80)

Closes #51 

I've also simplified the `dependency` collection since the `preprocess()` result should have the `dependencies` list.