### PR TITLE
Avoid overriding Svelte 3's default name assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,8 +252,9 @@ module.exports = function svelte(options = {}) {
 				const compiled = compile(
 					code,
 					Object.assign(base_options, fixed_options, {
-						name: capitalize(sanitize(id)),
 						filename: id
+					}, major_version >= 3 ? null : {
+						name: capitalize(sanitize(id))
 					})
 				);
 

--- a/test/test.js
+++ b/test/test.js
@@ -228,7 +228,7 @@ describe('rollup-plugin-svelte', () => {
 		});
 	});
 
-	it('intercepts warnings', async () => {
+	it('intercepts warnings', () => {
 		const warnings = [];
 		const handled = [];
 
@@ -242,16 +242,16 @@ describe('rollup-plugin-svelte', () => {
 			}
 		});
 
-		await transform.call({
+		return transform.call({
 			warn: warning => {
 				handled.push(warning);
 			}
 		}, `
 			<h1 aria-hidden>Hello world!</h1>
 			<marquee>wheee!!!</marquee>
-		`, 'test.html');
-
-		assert.deepEqual(warnings.map(w => w.code), ['a11y-hidden', 'a11y-distracting-elements']);
-		assert.deepEqual(handled.map(w => w.code), ['a11y-hidden']);
+		`, 'test.html').then(() => {
+			assert.deepEqual(warnings.map(w => w.code), ['a11y-hidden', 'a11y-distracting-elements']);
+			assert.deepEqual(handled.map(w => w.code), ['a11y-hidden']);
+		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,18 @@ describe('rollup-plugin-svelte', () => {
 		);
 	});
 
+	it('supports component name assignment', () => {
+		const { transform } = plugin();
+		return transform('', 'index.svelte').then(({ code }) => {
+			assert.notEqual(code.indexOf('class Index extends SvelteComponent'), -1);
+
+			return transform('', 'card/index.svelte');
+		}).then(({ code }) => {
+			assert.equal(code.indexOf('class Index extends SvelteComponent'), -1);
+			assert.notEqual(code.indexOf('class Card extends SvelteComponent'), -1);
+		});
+	});
+
 	it('creates a {code, map, dependencies} object, excluding the AST etc', () => {
 		const { transform } = plugin();
 		return transform('', 'test.html').then(compiled => {


### PR DESCRIPTION
As discussed in https://github.com/sveltejs/svelte/issues/3804 and https://github.com/rollup/rollup-plugin-svelte/issues/74, I'm not entirely sure about the implications for backwards compatibility.

I've tried adhering to existing code style, but let me know if anything needs changing (or feel free to do so yourself).

Tests were failing because Node 6 doesn't support `async`/`await`, so I've tried fixing that in an additional commit - unsuccessfully, as it appears Svelte itself uses `async`/`await`. Since April 2019 marked the end of life for Node 6 LTS, should we use Node 8 in `.travis.yml` instead?